### PR TITLE
feat: pass auth headers when fetching OpenAPI spec

### DIFF
--- a/src/commands/rest.ts
+++ b/src/commands/rest.ts
@@ -75,7 +75,21 @@ Examples:
       const readonly = resolveOption(findSharedOption("readonly"), opts.readonly, process.env, configFile) ?? false;
       const bindings = { ...(configFile?.options?.bind ?? {}), ...parseBindings(opts.bind) };
 
-      const spec = await loadSpec(specSource);
+      // Build auth headers before loading spec so protected specs can be fetched.
+      // Pass null for spec — securitySchemes aren't available yet (same as GraphQL flow).
+      const mergedEnv = mergeEnvWithConfig(process.env, configFile?.auth);
+      const cliHeaders = parseHeaderFlags(opts.header);
+      const preAuthHeaders = {
+        ...(configFile?.auth?.headers ?? {}),
+        ...resolveAuthHeaders(null, { cliHeaders, env: mergedEnv }),
+      };
+
+      const jwtAuth = buildJwtAuth(opts, configFile, process.env);
+      const specHeaders = jwtAuth
+        ? { ...preAuthHeaders, ...(await jwtAuth.getHeaders()) }
+        : preAuthHeaders;
+
+      const spec = await loadSpec(specSource, specHeaders);
       const serverName = spec.info.title || "api-to-mcp";
       const serverVersion = spec.info.version || "0.1.0";
 
@@ -114,16 +128,11 @@ Examples:
       const baseUrl =
         resolveOption(BASE_URL_OPTION, opts.baseUrl, process.env, configFile) ??
         resolveBaseUrl(spec.servers?.[0]?.url, specSource);
-      const mergedEnv = mergeEnvWithConfig(process.env, configFile?.auth);
+      // Rebuild auth headers with spec available — securitySchemes now resolved for API key placement
       const staticAuthHeaders = {
         ...(configFile?.auth?.headers ?? {}),
-        ...resolveAuthHeaders(spec, {
-          cliHeaders: parseHeaderFlags(opts.header),
-          env: mergedEnv,
-        }),
+        ...resolveAuthHeaders(spec, { cliHeaders, env: mergedEnv }),
       };
-
-      const jwtAuth = buildJwtAuth(opts, configFile, process.env);
 
       await startMcpServer({
         serverName,

--- a/src/spec-loader.ts
+++ b/src/spec-loader.ts
@@ -167,6 +167,8 @@ function formatHint(
 /**
  * Load an OpenAPI spec from a URL or local file path.
  * Supports both JSON and YAML formats.
+ * @param source - URL (http/https) or local file path to the OpenAPI spec
+ * @param headers - Optional HTTP headers to include when fetching spec from URL (ignored for local files)
  */
 export async function loadSpec(
   source: string,

--- a/src/spec-loader.ts
+++ b/src/spec-loader.ts
@@ -168,12 +168,16 @@ function formatHint(
  * Load an OpenAPI spec from a URL or local file path.
  * Supports both JSON and YAML formats.
  */
-export async function loadSpec(source: string): Promise<OpenAPISpec> {
+export async function loadSpec(
+  source: string,
+  headers?: Record<string, string>
+): Promise<OpenAPISpec> {
   let text: string;
   let hint: string | undefined;
 
   if (source.startsWith("http://") || source.startsWith("https://")) {
-    const response = await fetch(source);
+    const init = headers && Object.keys(headers).length > 0 ? { headers } : undefined;
+    const response = await fetch(source, ...init ? [init] : []);
     if (!response.ok) {
       throw new Error(
         `Failed to fetch spec from ${source}: ${response.status} ${response.statusText}`

--- a/src/spec-loader.ts
+++ b/src/spec-loader.ts
@@ -177,7 +177,7 @@ export async function loadSpec(
 
   if (source.startsWith("http://") || source.startsWith("https://")) {
     const init = headers && Object.keys(headers).length > 0 ? { headers } : undefined;
-    const response = await fetch(source, ...init ? [init] : []);
+    const response = await fetch(source, init);
     if (!response.ok) {
       throw new Error(
         `Failed to fetch spec from ${source}: ${response.status} ${response.statusText}`

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -1235,6 +1235,39 @@ describe("loadSpec — HTTP errors and unknown format", () => {
     );
   });
 
+  it("passes headers to fetch when provided", async () => {
+    const spec = { openapi: "3.0.0", info: { title: "T", version: "1" }, paths: { "/x": { get: { operationId: "x" } } } };
+    vi.stubGlobal("fetch", vi.fn());
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      text: async () => JSON.stringify(spec),
+      headers: { get: () => "application/json" },
+    } as unknown as Response);
+
+    await loadSpec("https://api.example.com/openapi.json", {
+      Authorization: "Bearer test-token",
+      "X-Custom": "value",
+    });
+
+    expect(fetch).toHaveBeenCalledWith("https://api.example.com/openapi.json", {
+      headers: { Authorization: "Bearer test-token", "X-Custom": "value" },
+    });
+  });
+
+  it("does not pass init options when no headers provided", async () => {
+    const spec = { openapi: "3.0.0", info: { title: "T", version: "1" }, paths: { "/x": { get: { operationId: "x" } } } };
+    vi.stubGlobal("fetch", vi.fn());
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      text: async () => JSON.stringify(spec),
+      headers: { get: () => "application/json" },
+    } as unknown as Response);
+
+    await loadSpec("https://api.example.com/openapi.json");
+
+    expect(fetch).toHaveBeenCalledWith("https://api.example.com/openapi.json");
+  });
+
   it("loads spec when content-type has no json/yaml hint (falls back to content detection)", async () => {
     const spec = { openapi: "3.0.0", info: { title: "T", version: "1" }, paths: {} };
     vi.stubGlobal("fetch", vi.fn());

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -1265,7 +1265,21 @@ describe("loadSpec — HTTP errors and unknown format", () => {
 
     await loadSpec("https://api.example.com/openapi.json");
 
-    expect(fetch).toHaveBeenCalledWith("https://api.example.com/openapi.json");
+    expect(fetch).toHaveBeenCalledWith("https://api.example.com/openapi.json", undefined);
+  });
+
+  it("does not pass init options when empty headers object provided", async () => {
+    const spec = { openapi: "3.0.0", info: { title: "T", version: "1" }, paths: { "/x": { get: { operationId: "x" } } } };
+    vi.stubGlobal("fetch", vi.fn());
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      text: async () => JSON.stringify(spec),
+      headers: { get: () => "application/json" },
+    } as unknown as Response);
+
+    await loadSpec("https://api.example.com/openapi.json", {});
+
+    expect(fetch).toHaveBeenCalledWith("https://api.example.com/openapi.json", undefined);
   });
 
   it("loads spec when content-type has no json/yaml hint (falls back to content detection)", async () => {

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -1320,6 +1320,31 @@ describe("loadSpec — local file", () => {
     }
   });
 
+  it("ignores headers when loading local file", async () => {
+    const { writeFile, unlink } = await import("node:fs/promises");
+    const { tmpdir } = await import("node:os");
+    const { join } = await import("node:path");
+
+    const spec = {
+      openapi: "3.0.0",
+      info: { title: "Local With Headers", version: "1.0.0" },
+      paths: { "/x": { get: { operationId: "x" } } },
+    };
+    const filePath = join(tmpdir(), `test-spec-headers-${Date.now()}.json`);
+    await writeFile(filePath, JSON.stringify(spec), "utf-8");
+
+    vi.stubGlobal("fetch", vi.fn());
+
+    try {
+      const loaded = await loadSpec(filePath, { Authorization: "Bearer token" });
+      expect(loaded.info.title).toBe("Local With Headers");
+      expect(fetch).not.toHaveBeenCalled();
+    } finally {
+      await unlink(filePath);
+      vi.unstubAllGlobals();
+    }
+  });
+
   it("throws for spec missing openapi field", async () => {
     vi.stubGlobal("fetch", vi.fn());
     vi.mocked(fetch).mockResolvedValue({


### PR DESCRIPTION
## Summary

- `loadSpec()` now accepts optional `headers` parameter and passes them to `fetch()` when loading spec over HTTP
- REST command builds auth headers (bearer token, API key, CLI `--header`, JWT) **before** `loadSpec()` — protected specs now work out of the box
- After spec is loaded, auth headers are rebuilt with `securitySchemes` for runtime API calls
- Brings REST command to parity with GraphQL, which already passed headers to introspection

Closes ONS-310

## Test plan

- [x] Unit test: `loadSpec(url, headers)` passes headers to `fetch()`
- [x] Unit test: `loadSpec(url)` without headers calls `fetch()` without init options (backward compat)
- [x] All 294 existing tests pass

Built [OnSteroids](https://onsteroids.ai)